### PR TITLE
Fix macOS camera permission and format handling for Rust/Objective-C compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["multimedia", "gui"]
 [dependencies]
 tauri = { version = "2.0", features = ["protocol-asset"] }
 tauri-plugin = "2.0"
-nokhwa = { version = "0.10", features = ["input-native", "output-threaded"] }
+nokhwa = { version = "0.10.10", features = ["input-native", "output-threaded"] }
 tokio = { version = "1.40", features = ["full"] }
 uuid = { version = "1.10", features = ["v4", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
@@ -24,6 +24,7 @@ log = "0.4"
 env_logger = "0.10"
 config = "0.14"
 toml = "0.8"
+block = "0.1"
 
 # ContextLite integration
 contextlite-client = { version = "2.0.7", optional = true }

--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -38,11 +38,13 @@ pub fn initialize_camera(params: CameraInitParams) -> Result<MacOSCamera, Camera
     
     // Create requested format based on the desired format
     let requested_format = RequestedFormat::new::<RgbFormat>(
-        RequestedFormatType::Exact(nokhwa::utils::FrameFormat::new(
-            nokhwa::utils::Resolution::new(params.format.width, params.format.height),
-            nokhwa::utils::FrameRate::new(params.format.fps as u32),
-            nokhwa::pixel_format::RgbFormat::Rgb,
-        ))
+        RequestedFormatType::Exact(
+            nokhwa::utils::CameraFormat::new(
+                nokhwa::utils::Resolution::new(params.format.width, params.format.height),
+                nokhwa::utils::FrameFormat::MJPEG, // or another valid variant
+                params.format.fps as u32,
+            )
+        )
     );
     
     let camera = Camera::new(nokhwa::utils::CameraIndex::Index(device_index), requested_format)


### PR DESCRIPTION
Hi, let me know if I'm missing something, but with these changes I was able to run the camera preview example locally on a 2.3 GHz 8-Core Intel Core i9 MacBook Pro.

* Replaces Objective-C block syntax in permissions.rs with a Rust closure wrapped using block::ConcreteBlock, enabling correct handling of macOS camera permission dialogs via the objc crate.
* Updates macos.rs to use the correct CameraFormat::new constructor signature for Nokhwa 0.10.x, ensuring frame format and frame rate are set as expected.
* Resolves build errors on macOS and enables proper permission requests and camera initialization.